### PR TITLE
Adding dependency for velocity in the proper location for rosdep use

### DIFF
--- a/packages/simulation/ezrassor_sim_control/CMakeLists.txt
+++ b/packages/simulation/ezrassor_sim_control/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ezrassor_sim_control)
-find_package(catkin REQUIRED COMPONENTS
-    velocity_controllers
-)
+find_package(catkin REQUIRED)
 catkin_package()
 catkin_python_setup()
 catkin_install_python(

--- a/packages/simulation/ezrassor_sim_control/package.xml
+++ b/packages/simulation/ezrassor_sim_control/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>controller_manager</depend>
+  <depend>velocity_controllers</depend>
   <depend>joint_state_controller</depend>
   <depend>robot_state_publisher</depend>
   <depend>rospy</depend>


### PR DESCRIPTION
The dependency check for the Debian velocity controllers package was in the incorrect location. This change moves that dependency check to package.xml for the sim control package so that rosdep can actually find it as a dependency. 