### PR TITLE
Prepending Xacro XML tags with <xacro: for simulation urdf files. 

### DIFF
--- a/packages/simulation/ezrassor_sim_description/launch/spawn_model.launch
+++ b/packages/simulation/ezrassor_sim_description/launch/spawn_model.launch
@@ -16,7 +16,7 @@
 
     <!--group ns="ezrassor$(arg id)"-->
     <!-- Spawn Robot -->
-    <param name="robot_description" command="$(find xacro)/xacro.py '$(find ezrassor_sim_description)/urdf/ezrassor.xacro'"/>
+    <param name="robot_description" command="xacro '$(find ezrassor_sim_description)/urdf/ezrassor.xacro'"/>
     <node name="ezrassor_spawn" pkg="gazebo_ros" type="spawn_model" output="screen"
         args="-urdf -param robot_description -model ezrassor$(arg id)
         -x $(arg x) -y $(arg y) -z $(arg z)

--- a/packages/simulation/ezrassor_sim_description/urdf/macros.xacro
+++ b/packages/simulation/ezrassor_sim_description/urdf/macros.xacro
@@ -2,61 +2,61 @@
 
 <robot name="ezrassor" xmlns:xacro="http://www.ros.org/wiki/xacro">
     <!-- Inertia Tensors Used: https://en.wikipedia.org/wiki/List_of_moments_of_inertia#List_of_3D_inertia_tensors -->
-    <macro name="cylinder_inertia" params="m r h">
+    <xacro:macro name="cylinder_inertia" params="m r h">
     <inertia  
         ixx="${m*((3*r*r)+(h*h))/12}" ixy = "0"                 ixz = "0"
                                   iyy="${m*((3*r*r)+(h*h))/12}" iyz = "0"
                                                             izz="${(m*(r*r))/2}"
     />
-    </macro>
+    </xacro:macro>
 
-    <macro name="box_inertia" params="m x y z">
+    <xacro:macro name="box_inertia" params="m x y z">
     <inertia  ixx="${m*(y*y+z*z)/12}" ixy = "0" ixz = "0"
         iyy="${m*(x*x+z*z)/12}" iyz = "0"
         izz="${m*(x*x+z*z)/12}"
     />
-    </macro>
+    </xacro:macro>
 
-    <macro name="sphere_inertia" params="m r">
+    <xacro:macro name="sphere_inertia" params="m r">
     <inertia  ixx="${2*m*r*r/5}" ixy = "0" ixz = "0"
         iyy="${2*m*r*r/5}" iyz = "0"
         izz="${2*m*r*r/5}"
     />
-    </macro>
+    </xacro:macro>
 
-    <macro name="slender_rod_along_y_inertia" params="m l mass_about">
-        <if value="${mass_about == 'end'}"> 
+    <xacro:macro name="slender_rod_along_y_inertia" params="m l mass_about">
+        <xacro:if value="${mass_about == 'end'}"> 
             <inertia  
                 ixx="${1/3*m*(l*l)}" ixy = "0"
                 ixz = "0" iyy="0" 
                 iyz = "0" izz="${1/3*m*(l*l)}" />
-        </if> 
-        <unless value="${mass_about == 'center'}"> 
+        </xacro:if> 
+        <xacro:unless value="${mass_about == 'center'}"> 
             <inertia  
                 ixx="${1/12*m*(l*l)}" ixy = "0"
                 ixz = "0" iyy="0" 
                 iyz = "0" izz="${1/12*m*(l*l)}" />
-        </unless> 
-    </macro>
+        </xacro:unless> 
+    </xacro:macro>
 
     <!-- VISUAL AND COLLISION MACROS -->
-    <macro name="robot_arm">
+    <xacro:macro name="robot_arm">
         <mesh filename="package://ezrassor_sim_description/meshes/drum_arm_short.dae" scale="1.0 1.0 1.0"></mesh> 
-    </macro>
+    </xacro:macro>
 
-    <macro name="robot_arm_drum">
+    <xacro:macro name="robot_arm_drum">
         <mesh filename="package://ezrassor_sim_description/meshes/drum.dae" scale="0.35 0.35 0.35"></mesh> 
-    </macro>
+    </xacro:macro>
 
-    <macro name="robot_wheel">
+    <xacro:macro name="robot_wheel">
         <mesh filename="package://ezrassor_sim_description/meshes/wheel.dae" scale="0.35 0.35 0.35"></mesh>  
-    </macro>
+    </xacro:macro>
     
-    <macro name="base_unit">
+    <xacro:macro name="base_unit">
         <mesh filename="package://ezrassor_sim_description/meshes/base_unit.dae" scale="0.35 0.35 0.35"></mesh>
-    </macro>
+    </xacro:macro>
 
-    <macro name="drum_arm">
+    <xacro:macro name="drum_arm">
         <mesh filename="package://ezrassor_sim_description/meshes/drum_arm.dae" scale="0.35 0.35 0.35"></mesh>
-    </macro>
+    </xacro:macro>
 </robot>


### PR DESCRIPTION
Also includes a change to use the xacro python node in the sim launch file. 
Closes #233 