### PR TITLE
Updating expo font usage for use in new SDK

### DIFF
--- a/controller/package.json
+++ b/controller/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "expo": "^34.0.3",
+    "expo-font": "^6.0.1",
     "react": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-34.0.0.tar.gz",
     "react-native-modal": "^7.0.2"

--- a/controller/src/components/app/ControllerScreen.js
+++ b/controller/src/components/app/ControllerScreen.js
@@ -6,7 +6,7 @@ import ControllerStyle from 'ezrassor-app/src/styles/controller';
 import {Robot, Operation} from 'ezrassor-app/src/enumerations/robot-commands';
 import { Linking, Text, View, TouchableHighlight, TouchableOpacity, Image, StatusBar, KeyboardAvoidingView, TextInput} from 'react-native';
 import { FontAwesome, MaterialCommunityIcons } from '@expo/vector-icons';
-import { Font } from 'expo';
+import * as Font  from 'expo-font';
 
 export default class ControllerScreen extends React.Component {
 


### PR DESCRIPTION
Unfortunately, I missed this completely in my last PR. With the upgrade of Expo's SDK, the old way of using expo fonts no longer works. This is why I change the import verbiage in the ControllerScreen. I only caught this after trying to run on my phone from a fresh instance of Expo which forces a new app download. 

Thanks!