### PR TITLE
Controller typo fixes

### DIFF
--- a/controller/app.json
+++ b/controller/app.json
@@ -3,7 +3,8 @@
     "android":{
       "adaptiveIcon.backgroundImage": "./assets/adaptive-icon.png",
       "adaptiveIcon.backgroundColor": "slategray",
-      "permissions": []
+      "permissions": [],
+      "versionCode": 2
     },
     "name": "EZ-RASSOR Controller",
     "description": "This controller application has been made for the EZ-RASSOR, an excavation robot that runs on ROS.",

--- a/controller/app.json
+++ b/controller/app.json
@@ -11,7 +11,7 @@
     "privacy": "public",
     "sdkVersion": "34.0.0",
     "platforms": ["ios", "android"],
-    "version": "1.1.0",
+    "version": "1.1.1",
     "orientation": "landscape",
     "icon": "./assets/color-icon.png",
     "splash": {

--- a/controller/app.json
+++ b/controller/app.json
@@ -1,8 +1,11 @@
 {
   "expo": {
     "android":{
-      "adaptiveIcon.backgroundImage": "./assets/adaptive-icon.png",
-      "adaptiveIcon.backgroundColor": "slategray",
+      "adaptiveIcon": {
+        "backgroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#708090"
+      },
+      "package": "com.FlaSpaceInst.EZRASSORController",
       "permissions": [],
       "versionCode": 2
     },
@@ -28,9 +31,6 @@
     ],
     "ios": {
       "supportsTablet": true
-    },
-    "android": {
-      "package": "com.FlaSpaceInst.EZRASSORController"
     }
   }
 }

--- a/controller/src/components/app/ControllerScreen.js
+++ b/controller/src/components/app/ControllerScreen.js
@@ -90,7 +90,7 @@ export default class ControllerScreen extends React.Component {
           <TouchableHighlight style={{ flex: 1, marginHorizontal: 15, justifyContent: 'center' }}>
             <View>
               <View style={{ flexDirection: 'row', marginVertical: 15, justifyContent: 'center' }}>
-                <Text style={ControllerStyle.textLarge}>Activate Autonomout Function(s)</Text>
+                <Text style={ControllerStyle.textLarge}>Activate Autonomous Function(s)</Text>
               </View>
               <View style={{ flexDirection: 'row', marginVertical: 15, justifyContent: 'center' }}> 
                   <TouchableOpacity style={ControllerStyle.modalButton} onPress={()=>this.setXYModalVisible(true)}>
@@ -131,7 +131,7 @@ export default class ControllerScreen extends React.Component {
                   <Text style={ControllerStyle.columnText}>Camilo Lozano</Text>
                   <Text style={ControllerStyle.columnText}>Cameron Taylor</Text>
                   <Text style={ControllerStyle.columnText}>Harrison Black</Text>
-                  <Text style={ControllerStyle.columnText}>Ron Marrero</Text>
+                  <Text style={ControllerStyle.columnText}>Ronald Marrero</Text>
                   <Text style={ControllerStyle.columnText}>Samuel Lewis</Text>
                 </View>
                 <View style={{marginHorizontal:5}}/>
@@ -151,7 +151,7 @@ export default class ControllerScreen extends React.Component {
               <View style={{marginVertical: 10}}/>
               <Text style={[ControllerStyle.textTiny, ControllerStyle.columnText]}>Visit
                   <Text style={[ControllerStyle.textTiny, ControllerStyle.columnHyperlink]} onPress={() => Linking.openURL('https://github.com/FlaSpaceInst/EZ-RASSOR')}> our GitHub repository </Text>
-                  for more information
+                  for more information.
               </Text>
             </View>
           </View>

--- a/controller/src/styles/controller.js
+++ b/controller/src/styles/controller.js
@@ -107,7 +107,7 @@ const ControllerStyle = StyleSheet.create({
   },
 
   columnHyperlink: {
-    color: 'blue',
+    color: 'cornflowerblue',
     textAlign: 'center'
   },
 


### PR DESCRIPTION
Closes #301 

The typos pointed out have been corrected. The new updated version of the EZ-RASSOR Controller (v1.1.1 on the Google Play Store) was successfully published as well and is now live. 