### PR TITLE
Update simulation to use depth camera instead of stereo camera

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/viso2"]
-	path = external/viso2
-	url = http://github.com/srv/viso2

--- a/packages/autonomy/ezrassor_autonomous_control/launch/autonomous_control.launch
+++ b/packages/autonomy/ezrassor_autonomous_control/launch/autonomous_control.launch
@@ -39,6 +39,12 @@
       <remap from="image" to="depth/image_raw"/>
     </node>
 
+    <node pkg="depthimage_to_laserscan" type="depthimage_to_laserscan"
+          name="depthimage_to_laserscan">
+      <remap from="image" to="depth/image_raw"/>
+      <remap from="camera_info" to="depth/camera_info"/>
+    </node>
+
     <node pkg="ezrassor_autonomous_control"
           type="depth_estimator"
           name="depth_estimator"/>

--- a/packages/autonomy/ezrassor_autonomous_control/launch/autonomous_control.launch
+++ b/packages/autonomy/ezrassor_autonomous_control/launch/autonomous_control.launch
@@ -12,7 +12,6 @@
   <arg name="max_linear_velocity" default="1"/>
   <arg name="max_angular_velocity" default="1"/>
   <arg name="enable_cameras" default="true"/>
-  <arg name="enable_real_odometry" default="false"/>
 
   <!-- Launch the autonomous control node. -->
   <node pkg="ezrassor_autonomous_control"
@@ -23,7 +22,6 @@
     <param name="digsite_y_coord" value="$(arg digsite_y_coord)"/>
     <param name="max_linear_velocity" value="$(arg max_linear_velocity)"/>
     <param name="max_angular_velocity" value="$(arg max_angular_velocity)"/>
-    <param name="enable_real_odometry" value="$(arg enable_real_odometry)"/>
     <param name="wheel_instructions_topic"
            value="$(arg wheel_instructions_topic)"/>
     <param name="front_arm_instructions_topic"
@@ -55,13 +53,5 @@
     <node pkg="ezrassor_autonomous_control"
           type="transform_broadcaster"
           name="transform_broadcaster"/>
-  </group>
-
-  <group if="$(arg enable_real_odometry)">
-    <node pkg="viso2_ros" type="stereo_odometer" name="odometry">
-      <param name="sensor_frame_id" value="left_camera_optical_frame"/>
-      <remap from="stereo" to="/"/>
-      <remap from="image" to="/image_rect_color"/>
-    </node>
   </group>
 </launch>

--- a/packages/autonomy/ezrassor_autonomous_control/launch/autonomous_control.launch
+++ b/packages/autonomy/ezrassor_autonomous_control/launch/autonomous_control.launch
@@ -35,15 +35,8 @@
   </node>
 
   <group if="$(arg enable_cameras)">
-    <node pkg="stereo_image_proc" type="stereo_image_proc" name="stereo_image_proc">
-      <param name="min_disparity" type="int" value="3"/>
-      <param name="texture_threshold" type="int" value="100"/>
-      <param name="speckle_size" type="int" value="200"/>
-    </node>
-
-    <node pkg="image_view" type="stereo_view" name="stereo_view">
-      <remap from="stereo" to="/"/>
-      <remap from="image" to="/image_rect_color"/>
+    <node pkg="image_view" type="image_view" name="image_view">
+      <remap from="image" to="depth/image_raw"/>
     </node>
 
     <node pkg="ezrassor_autonomous_control"

--- a/packages/autonomy/ezrassor_autonomous_control/nodes/autonomous_control
+++ b/packages/autonomy/ezrassor_autonomous_control/nodes/autonomous_control
@@ -11,15 +11,13 @@ front_drum_topic = rospy.get_param('autonomous_control/front_drum_instructions_t
 back_drum_topic = rospy.get_param('autonomous_control/back_drum_instructions_topic')
 max_linear_velocity = rospy.get_param('autonomous_control/max_linear_velocity')
 max_angular_velocity = rospy.get_param('autonomous_control/max_angular_velocity')
-real_odometry = rospy.get_param('autonomous_control/enable_real_odometry')
 
 autonomous_control.on_start_up(target_x,
                                target_y,
-                               movement_topic, 
+                               movement_topic,
                                front_arm_topic,
                                back_arm_topic,
                                front_drum_topic,
-                               back_drum_topic, 
+                               back_drum_topic,
                                float(max_linear_velocity),
-                               float(max_angular_velocity),
-                               bool(real_odometry))
+                               float(max_angular_velocity))

--- a/packages/autonomy/ezrassor_autonomous_control/package.xml
+++ b/packages/autonomy/ezrassor_autonomous_control/package.xml
@@ -21,7 +21,8 @@
   <depend>python-numpy</depend>
   <depend>python-opencv</depend>
   <depend>robot_state_publisher</depend>
+  <depend>image_view</depend>
+  <depend>depthimage_to_laserscan</depend>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
-  <depend>image_view</depend>
 </package>

--- a/packages/autonomy/ezrassor_autonomous_control/package.xml
+++ b/packages/autonomy/ezrassor_autonomous_control/package.xml
@@ -18,17 +18,10 @@
   <depend>cv_bridge</depend>
   <depend>gazebo_msgs</depend>
   <depend>sensor_msgs</depend>
-  <depend>stereo_msgs</depend>
   <depend>python-numpy</depend>
   <depend>python-opencv</depend>
   <depend>robot_state_publisher</depend>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>message_generation</build_depend>
-
-  <!-- These dependencies are required by Viso2, but they didn't include them
-       in their package.xml... -->
-  <depend>viso2_ros</depend>
   <depend>image_view</depend>
-  <depend>message_runtime</depend>
-  <depend>stereo_image_proc</depend>
 </package>

--- a/packages/autonomy/ezrassor_autonomous_control/source/ezrassor_autonomous_control/ai_objects.py
+++ b/packages/autonomy/ezrassor_autonomous_control/source/ezrassor_autonomous_control/ai_objects.py
@@ -1,6 +1,5 @@
 import rospy
 from std_msgs.msg import String, Float32, Bool
-from nav_msgs.msg import Odometry
 from gazebo_msgs.msg import LinkStates
 from sensor_msgs.msg import JointState
 from geometry_msgs.msg import Point, Twist
@@ -10,8 +9,8 @@ import math
 from random import uniform
 
 class WorldState():
-    """ World State Object Representing 
-        All Sensor Data 
+    """ World State Object Representing
+        All Sensor Data
     """
 
     def __init__(self):
@@ -38,18 +37,11 @@ class WorldState():
 
         self.front_arm_angle = data.position[1]
         self.back_arm_angle = data.position[0]
-    
 
-    def odometryCallBack(self, data):
-        """ Set state_flags world position data. """
-
-        self.positionX = data.pose.pose.position.z
-        self.positionY = data.pose.pose.position.y
-        self.heading = nf.quaternion_to_yaw(data.pose.pose.orientation)
 
     def simStateCallBack(self, data):
-        """ More accurate position data to use for 
-            testing and experimentation. 
+        """ More accurate position data to use for
+            testing and experimentation.
         """
         index = 0
 
@@ -61,14 +53,14 @@ class WorldState():
             rospy.logdebug("Failed to get index. Skipping...")
 
             return
-            
+
 
         self.positionX = data.pose[index].position.x
         self.positionY = data.pose[index].position.y
-        
+
         self.positionX = data.pose[index].position.x
         self.positionY = data.pose[index].position.y
-        
+
         heading = nf.quaternion_to_yaw(data.pose[index]) * 180/math.pi
 
         if heading > 0:
@@ -101,27 +93,27 @@ class ROSUtility():
     """
 
     def __init__(self, movement_topic, front_arm_topic, back_arm_topic,
-                 front_drum_topic, back_drum_topic, 
+                 front_drum_topic, back_drum_topic,
                  max_linear_velocity, max_angular_velocity):
         """ Initialize the ROS Utility Object. """
-        
-        self.movement_pub = rospy.Publisher(movement_topic, 
-                                            Twist, 
+
+        self.movement_pub = rospy.Publisher(movement_topic,
+                                            Twist,
                                             queue_size=10)
-        self.front_arm_pub = rospy.Publisher(front_arm_topic, 
-                                             Float32, 
+        self.front_arm_pub = rospy.Publisher(front_arm_topic,
+                                             Float32,
                                              queue_size=10)
-        self.back_arm_pub = rospy.Publisher(back_arm_topic, 
-                                            Float32, 
+        self.back_arm_pub = rospy.Publisher(back_arm_topic,
+                                            Float32,
                                             queue_size=10)
-        self.front_drum_pub = rospy.Publisher(front_drum_topic, 
-                                              Float32, 
+        self.front_drum_pub = rospy.Publisher(front_drum_topic,
+                                              Float32,
                                               queue_size=10)
-        self.back_drum_pub = rospy.Publisher(back_drum_topic, 
-                                             Float32, 
+        self.back_drum_pub = rospy.Publisher(back_drum_topic,
+                                             Float32,
                                              queue_size=10)
-        self.control_pub = rospy.Publisher('secondary_override_toggle', 
-                                           Bool, 
+        self.control_pub = rospy.Publisher('secondary_override_toggle',
+                                           Bool,
                                            queue_size=10)
         self.rate = rospy.Rate(45) # 10hz
 
@@ -132,7 +124,7 @@ class ROSUtility():
 
         self.threshold = .5
 
-    def publish_actions(self, movement, front_arm, back_arm, 
+    def publish_actions(self, movement, front_arm, back_arm,
                         front_drum, back_drum):
         """ Publishes actions for all joints and motors """
 

--- a/packages/autonomy/ezrassor_autonomous_control/source/ezrassor_autonomous_control/autonomous_control.py
+++ b/packages/autonomy/ezrassor_autonomous_control/source/ezrassor_autonomous_control/autonomous_control.py
@@ -3,7 +3,6 @@ import sys
 
 from std_msgs.msg import Int8, Int16, String
 from geometry_msgs.msg import Point
-from nav_msgs.msg import Odometry
 from gazebo_msgs.msg import LinkStates
 from sensor_msgs.msg import JointState
 from sensor_msgs.msg import Imu
@@ -14,23 +13,22 @@ import ai_objects as obj
 import auto_functions as af
 import utility_functions as uf
 
-def on_start_up(target_x, target_y, movement_topic, front_arm_topic, 
+def on_start_up(target_x, target_y, movement_topic, front_arm_topic,
                 back_arm_topic, front_drum_topic, back_drum_topic,
-                max_linear_velocity=1, max_angular_velocity=1, 
-                real_odometry=False):
+                max_linear_velocity=1, max_angular_velocity=1):
     """ Initialization Function  """
 
-    # ROS Node Init Parameters 
+    # ROS Node Init Parameters
     rospy.init_node('autonomous_control')
-    
+
     #Create Utility Objects
     world_state = obj.WorldState()
-    ros_util = obj.ROSUtility(movement_topic, 
+    ros_util = obj.ROSUtility(movement_topic,
                               front_arm_topic,
-                              back_arm_topic, 
+                              back_arm_topic,
                               front_drum_topic,
-                              back_drum_topic, 
-                              max_linear_velocity, 
+                              back_drum_topic,
+                              max_linear_velocity,
                               max_angular_velocity)
 
     target_location = Point()
@@ -46,38 +44,31 @@ def on_start_up(target_x, target_y, movement_topic, front_arm_topic,
     world_state.dig_site = temp
 
     # Setup Subscriber Callbacks
-    if real_odometry:
-        # This topic will be changed to represent whatever
-        # topic the odometry data is being published to
-        rospy.Subscriber('stereo_odometer/odometry', 
-                         Odometry, 
-                         world_state.odometryCallBack)
-    else:
-        rospy.Subscriber('/gazebo/link_states', 
-                         LinkStates, 
+    rospy.Subscriber('/gazebo/link_states',
+                         LinkStates,
                          world_state.simStateCallBack)
-    
-    rospy.Subscriber('imu', 
-                     Imu, 
+
+    rospy.Subscriber('imu',
+                     Imu,
                      world_state.imuCallBack)
-    rospy.Subscriber('joint_states', 
-                     JointState, 
+    rospy.Subscriber('joint_states',
+                     JointState,
                      world_state.jointCallBack)
-    rospy.Subscriber('obstacle_detect', 
-                     Int8, 
+    rospy.Subscriber('obstacle_detect',
+                     Int8,
                      world_state.visionCallBack)
-    rospy.Subscriber('autonomous_toggles', 
-                     Int8, 
+    rospy.Subscriber('autonomous_toggles',
+                     Int8,
                      ros_util.autoCommandCallBack)
-    
+
     rospy.loginfo('Autonomous control initialized.')
 
     autonomous_control_loop(world_state, ros_util)
 
 
 def full_autonomy(world_state, ros_util):
-    """ Full Autonomy Loop Function """ 
-    
+    """ Full Autonomy Loop Function """
+
     rospy.loginfo('Full autonomy activated.')
 
     while(ros_util.auto_function_command == 16):
@@ -86,21 +77,21 @@ def full_autonomy(world_state, ros_util):
             break
         af.auto_dig(world_state, ros_util, 7)
         if ros_util.auto_function_command != 16:
-            break       
+            break
         af.auto_dock(world_state, ros_util)
         if ros_util.auto_function_command != 16:
-            break       
+            break
         af.auto_dump(world_state, ros_util, 4)
         world_state.target_location.x = world_state.dig_site.x
         world_state.target_location.y = world_state.dig_site.y
-    
+
     world_state.target_location.x = world_state.dig_site.x
     world_state.target_location.y = world_state.dig_site.y
-    
+
 
 def autonomous_control_loop(world_state, ros_util):
     """ Control Auto Functions based on auto_function_command input. """
-    
+
     while(True):
         while ros_util.auto_function_command == 0 or ros_util.auto_function_command == 32:
             ros_util.publish_actions('stop', 0, 0, 0, 0)
@@ -121,9 +112,7 @@ def autonomous_control_loop(world_state, ros_util):
         else:
             rospy.loginfo('Invalid auto-function request: %s.',
                           str(ros_util.auto_function_command))
-        
+
         ros_util.auto_function_command = 0
         ros_util.publish_actions('stop', 0, 0, 0, 0)
         ros_util.control_pub.publish(False)
-
-

--- a/packages/autonomy/ezrassor_autonomous_control/source/ezrassor_autonomous_control/depth_estimator.py
+++ b/packages/autonomy/ezrassor_autonomous_control/source/ezrassor_autonomous_control/depth_estimator.py
@@ -6,85 +6,26 @@ import numpy as np
 from numpy import inf, nan
 import cv2
 from cv_bridge import CvBridge, CvBridgeError
-from stereo_msgs.msg import DisparityImage
+from sensor_msgs.msg import LaserScan
 import std_msgs
 from std_msgs.msg import Int8
 import time
 
-LEFT = 0
-RIGHT = 1
-
-# Written by Tyler Duncan
-
 # Obstacle Detection
 def obst_detect(data):
-
     pub = rospy.Publisher('obstacle_detect', Int8, queue_size=10)
 
     """Set thresholds."""
-    if data[RIGHT].min() > data[LEFT].min() and data[LEFT].min() < 1.5:
-        rospy.logdebug("MOVE RIGHT!")
-        pub.publish(1)
-    elif data[LEFT].min() > data[RIGHT].min() and data[RIGHT].min() < 1.5:
-        rospy.logdebug("MOVE LEFT!")
-        pub.publish(2)
-    elif data[LEFT].min() < 1 and data[RIGHT].min() < 1.5:
+    if np.nanmin(data.ranges) < 1.0:
         rospy.logdebug("MOVE BACKWARD!")
         pub.publish(3)
     else:
         rospy.logdebug("MOVE FORWARD!")
         pub.publish(0)
 
-
-def callback(data):
-
-    """Convert disparity image message to Numpy matrix"""
-    bridge = CvBridge()
-    cv_image = bridge.imgmsg_to_cv2(data.image, "8UC1").astype("float64")
-
-    """Convert disparity values to distance values.
-
-    Using this equation:
-
-                                Z[i][j] = fT / d[i][j]
-
-    Where f is the focal distance, T is the baseline distance, d is the disparity value
-    at postion (i, j), and Z is distance from the camera to the pixel (i, j).
-
-    Every entry in the disparity matrix must inverted to it's reciprocal.
-    Then multiplied by both the focal length of both cameras, f, and the baseline
-    distance between the cameras, T.
-    This is done by performing a Hadamard Product (element-wise) on the disparty
-    matrix.
-    """
-
-    depth_mat = np.multiply((data.f * data.T), np.reciprocal(cv_image.astype("float64")))
-
-    """Remove all infinite values and nan values from distance matrix that may be present."""
-    depth_mat[depth_mat == inf] = 1000
-    depth_mat[depth_mat == nan] = 1000
-
-    """Initialize values for pooling."""
-    M, N = depth_mat.shape
-    K = 8
-    L = 8
-    MK = M // K
-    NL = N // L
-
-    """Perform mean pooling on distance matrix to minimize noise."""
-    mean_pool = depth_mat[:MK*K, :NL*L].reshape(MK, K, NL, L).mean(axis=(1,3))
-
-    """Divide distance matrix into two vertical columns."""
-    div_mat = np.split(mean_pool[20], 2, axis=0)
-    # print(div_mat)
-
-    """Perform obstacle detection."""
-    obst_detect(div_mat)
-
-
 def depth_estimator():
     rospy.init_node('depth_estimator')
-    rospy.Subscriber("disparity", DisparityImage, callback)
+    rospy.Subscriber("scan", LaserScan, obst_detect)
     rospy.loginfo("Depth estimator initialized.")
     rospy.spin()
 

--- a/packages/extras/ezrassor_launcher/launch/configurable_communication.launch
+++ b/packages/extras/ezrassor_launcher/launch/configurable_communication.launch
@@ -8,7 +8,6 @@
   <arg name="digsite_x_coord" default="default"/>
   <arg name="digsite_y_coord" default="default"/>
   <arg name="enable_cameras" default="default"/>
-  <arg name="enable_real_odometry" default="default"/>
 
   <!-- A large collection of constants that this launch file needs. -->
   <arg name="wheel_instructions_topic" value="wheel_instructions"/>
@@ -96,9 +95,6 @@
         <arg name="enable_cameras"
              value="$(arg enable_cameras)"
              unless="$(eval enable_cameras == 'default')"/>
-        <arg name="enable_real_odometry"
-             value="$(arg enable_real_odometry)"
-             unless="$(eval enable_real_odometry == 'default')"/>
       </include>
       <include file="$(find ezrassor_topic_switch)/launch/topic_switch.launch">
         <arg name="node_name" value="$(arg wheel_switch_name)"/>
@@ -166,9 +162,6 @@
         <arg name="enable_cameras"
              value="$(arg enable_cameras)"
              unless="$(eval enable_cameras == 'default')"/>
-        <arg name="enable_real_odometry"
-             value="$(arg enable_real_odometry)"
-             unless="$(eval enable_real_odometry == 'default')"/>
       </include>
     </group>
   </group>

--- a/packages/extras/ezrassor_launcher/launch/configurable_simulation.launch
+++ b/packages/extras/ezrassor_launcher/launch/configurable_simulation.launch
@@ -19,7 +19,6 @@
   <arg name="recording" default="default"/>
   <arg name="use_sim_time" default="default"/>
   <arg name="enable_cameras" default="default"/>
-  <arg name="enable_real_odometry" default="default"/>
 
   <!-- Launch the communication system for a simulated robot. -->
   <group ns="ezrassor$(arg robot_count)">
@@ -38,7 +37,6 @@
            value="$(eval str(digsite_y_coords).split()[robot_count - 1])"
            unless="$(eval digsite_y_coords == 'default')"/>
       <arg name="enable_cameras" value="$(arg enable_cameras)"/>
-      <arg name="enable_real_odometry" value="$(arg enable_real_odometry)"/>
     </include>
 
     <!-- Spawn the model. -->
@@ -107,6 +105,5 @@
     <arg name="recording" value="$(arg recording)"/>
     <arg name="use_sim_time" value="$(arg use_sim_time)"/>
     <arg name="enable_cameras" value="$(arg enable_cameras)"/>
-    <arg name="enable_real_odometry" value="$(arg enable_real_odometry)"/>
   </include>
 </launch>

--- a/packages/simulation/ezrassor_sim_description/urdf/ezrassor.gazebo
+++ b/packages/simulation/ezrassor_sim_description/urdf/ezrassor.gazebo
@@ -95,7 +95,7 @@
         <depthImageInfoTopicName>depth/camera_info</depthImageInfoTopicName>
         <pointCloudTopicName>depth/points</pointCloudTopicName>
         <frameName>optical_frame</frameName>
-        <pointCloudCutoff>0.5</pointCloudCutoff>
+        <pointCloudCutoff>0.05</pointCloudCutoff>
         <pointCloudCutoffMax>3.0</pointCloudCutoffMax>
         <distortionK1>0.00000001</distortionK1>
         <distortionK2>0.00000001</distortionK2>

--- a/packages/simulation/ezrassor_sim_description/urdf/ezrassor.gazebo
+++ b/packages/simulation/ezrassor_sim_description/urdf/ezrassor.gazebo
@@ -20,111 +20,93 @@
   <gazebo reference="drum_front_hinge">
    <sensor name="force_torque" type="force_torque">
     <update_rate>1</update_rate>
-   </sensor> 
+   </sensor>
   </gazebo>
 
   <gazebo reference="drum_front">
     <selfCollide>1</selfCollide>
   </gazebo>
-  
+
   <gazebo reference="drum_back">
     <selfCollide>1</selfCollide>
   </gazebo>
 
   <!-- Wheels -->
   <gazebo reference="left_wheel_front">
-    <selfCollide>1</selfCollide>    
+    <selfCollide>1</selfCollide>
     <mu1 value=".8"/>
     <mu2 value=".8"/>
     <kp  value="10000000.0" />
     <kd  value="1.0" />
-    <fdir1 value="1 0 0"/> 
+    <fdir1 value="1 0 0"/>
   </gazebo>
-  
+
   <gazebo reference="left_wheel_back">
-    <selfCollide>1</selfCollide>    
+    <selfCollide>1</selfCollide>
     <mu1 value=".8"/>
     <mu2 value=".8"/>
     <kp  value="10000000.0" />
     <kd  value="1.0" />
-    <fdir1 value="1 0 0"/> 
+    <fdir1 value="1 0 0"/>
   </gazebo>
 
   <gazebo reference="right_wheel_front">
-    <selfCollide>1</selfCollide>    
+    <selfCollide>1</selfCollide>
     <mu1 value=".8"/>
     <mu2 value=".8"/>
     <kp  value="10000000.0" />
     <kd  value="1.0" />
-    <fdir1 value="1 0 0"/> 
+    <fdir1 value="1 0 0"/>
   </gazebo>
-  
+
   <gazebo reference="right_wheel_back">
     <selfCollide>1</selfCollide>
     <mu1 value=".8"/>
     <mu2 value=".8"/>
     <kp  value="10000000.0" />
     <kd  value="1.0" />
-    <fdir1 value="1 0 0"/> 
+    <fdir1 value="1 0 0"/>
   </gazebo>
 
   <!-- Cameras -->
-  <gazebo reference="stereo_camera_front">
-    <sensor type="multicamera" name="stereo_camera">
-      <update_rate>60.0</update_rate>
-      <camera name="left">
-        <focalLength>0</focalLength>
-        <pose> 0 0.035 0 0 0 0 </pose>
-        <horizontal_fov>1.3962634</horizontal_fov>
+  <gazebo reference="depth_camera_front">
+    <sensor name="depth_camera_front_camera" type="depth">
+      <update_rate>20</update_rate>
+      <camera>
+        <horizontal_fov>1.047198</horizontal_fov>
         <image>
           <width>640</width>
           <height>480</height>
           <format>R8G8B8</format>
         </image>
         <clip>
-          <near>0.02</near>
-          <far>300</far>
+          <near>0.05</near>
+          <far>3</far>
         </clip>
-        <noise>
-          <type>gaussian</type>
-          <mean>0.0</mean>
-          <stddev>0.007</stddev>
-        </noise>
       </camera>
-      <camera name="right">
-        <pose>0 -0.035 0 0 0 0</pose>
-        <focalLength>0</focalLength>
-        <horizontal_fov>1.3962634</horizontal_fov>
-        <image>
-          <width>640</width>
-          <height>480</height>
-          <format>R8G8B8</format>
-        </image>
-        <clip>
-          <near>0.02</near>
-          <far>300</far>
-        </clip>
-        <noise>
-          <type>gaussian</type>
-          <mean>0.0</mean>
-          <stddev>0.007</stddev>
-        </noise>
-      </camera>
-      <plugin name="stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
-        <focalLength>0</focalLength>
+      <plugin name="depth_camera_front_controller" filename="libgazebo_ros_openni_kinect.so">
+        <baseline>0.2</baseline>
         <alwaysOn>true</alwaysOn>
         <updateRate>0.0</updateRate>
         <cameraName></cameraName>
-        <imageTopicName>image_raw</imageTopicName>
-        <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-        <frameName>left_camera_optical_frame</frameName>
-        <rightFrameName>right_camera_optical_frame</rightFrameName>
-        <hackBaseline>0.07</hackBaseline>
-        <distortionK1>0.0</distortionK1>
-        <distortionK2>0.0</distortionK2>
-        <distortionK3>0.0</distortionK3>
-        <distortionT1>0.0</distortionT1>
-        <distortionT2>0.0</distortionT2>
+        <imageTopicName>color/image_raw</imageTopicName>
+        <cameraInfoTopicName>color/camera_info</cameraInfoTopicName>
+        <depthImageTopicName>depth/image_raw</depthImageTopicName>
+        <depthImageInfoTopicName>depth/camera_info</depthImageInfoTopicName>
+        <pointCloudTopicName>depth/points</pointCloudTopicName>
+        <frameName>optical_frame</frameName>
+        <pointCloudCutoff>0.5</pointCloudCutoff>
+        <pointCloudCutoffMax>3.0</pointCloudCutoffMax>
+        <distortionK1>0.00000001</distortionK1>
+        <distortionK2>0.00000001</distortionK2>
+        <distortionK3>0.00000001</distortionK3>
+        <distortionT1>0.00000001</distortionT1>
+        <distortionT2>0.00000001</distortionT2>
+        <CxPrime>0</CxPrime>
+        <Cx>0</Cx>
+        <Cy>0</Cy>
+        <focalLength>0</focalLength>
+        <hackBaseline>0</hackBaseline>
       </plugin>
     </sensor>
   </gazebo>
@@ -149,7 +131,7 @@
       <pose>0 0 0 0 0 0</pose>
     </sensor>
   </gazebo>
-  
+
   <gazebo>
     <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
     </plugin>

--- a/packages/simulation/ezrassor_sim_description/urdf/ezrassor.xacro
+++ b/packages/simulation/ezrassor_sim_description/urdf/ezrassor.xacro
@@ -148,7 +148,7 @@
       <cylinder_inertia m="5" r="0.18" h="0.2"/>
     </inertial>
   </link>
-  
+
   <link name="arm_front">
     <collision name="collision">
       <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -167,7 +167,7 @@
       <mass value="5"/>
       <cylinder_inertia m="5" r="0.05" h="0.3"/>
     </inertial>
-  </link> 
+  </link>
 
 
   <link name="arm_back">
@@ -244,7 +244,7 @@
       <mass value="5"/>
       <cylinder_inertia m="5" r="0.1839" h="1.0"/>
     </inertial>
-  </link> 
+  </link>
 
   <!-- Transmissions -->
   <transmission name="left_wheel_front_tran">
@@ -336,7 +336,7 @@
   </transmission>
 
   <!-- Front Camera Added -->
-  <link name="stereo_camera_front">
+  <link name="depth_camera_front">
     <collision>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
@@ -390,7 +390,7 @@
     <parent link="base_link"/>
     <child link="body"/>
   </joint>
-  
+
   <joint name="imu_joint" type="fixed">
     <axis xyz="0 0 0" />
     <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -402,7 +402,7 @@
     <origin xyz=".3 0 -.1" rpy="0 0 0"/>
     <axis xyz="0 1 0" />
     <parent link="base_link"/>
-    <child link="stereo_camera_front"/>
+    <child link="depth_camera_front"/>
   </joint>
 
   <joint type="continuous" name="left_wheel_front_hinge">
@@ -440,7 +440,7 @@
     <limit effort="100" velocity="100"/>
     <joint_properties damping="0.0" friction="0.0"/>
   </joint>
-  
+
   <joint type="continuous" name="arm_front_hinge">
     <origin xyz="0.20 0 0" rpy="3.1415 0 0"/>
     <child link="arm_front"/>
@@ -467,7 +467,7 @@
     <limit effort="100" velocity="100"/>
     <joint_properties damping="0.0" friction="0.0"/>
   </joint>
-  
+
   <joint type="continuous" name="drum_back_hinge">
     <origin xyz="-0.388245 0 0" rpy="3.1415 0 0"/>
     <child link="drum_back"/>


### PR DESCRIPTION
In order to support depth cameras, this PR removes everything associated with stereo cameras and replaces it with depth cameras. The major changes are:
- Replacing the simulated stereo camera with a simulated Kinect (the OpenNI Kinect is the standard way to simulate a depth camera in Gazebo from what I understand).
- Removing the external viso2 package since we plan to implement visual odometry using RGB-D images, which viso2 does not support.
- Refactoring obstacle detection to use laser scan data made from the depth image produced by the depth camera instead of using the output from the stereo camera. The obstacle detection functionality in this PR is very basic but we have plans for expanding it significantly in SD2.