### PR TITLE
Reconfigure simulated depth camera according to specs of RealSense D435i

### DIFF
--- a/packages/simulation/ezrassor_sim_description/urdf/ezrassor.gazebo
+++ b/packages/simulation/ezrassor_sim_description/urdf/ezrassor.gazebo
@@ -71,17 +71,17 @@
   <!-- Cameras -->
   <gazebo reference="depth_camera_front">
     <sensor name="depth_camera_front_camera" type="depth">
-      <update_rate>20</update_rate>
+      <update_rate>30</update_rate>
       <camera>
-        <horizontal_fov>1.047198</horizontal_fov>
+        <horizontal_fov>1.29154</horizontal_fov>
         <image>
           <width>640</width>
           <height>480</height>
           <format>R8G8B8</format>
         </image>
         <clip>
-          <near>0.05</near>
-          <far>3</far>
+          <near>0.105</near>
+          <far>10</far>
         </clip>
       </camera>
       <plugin name="depth_camera_front_controller" filename="libgazebo_ros_openni_kinect.so">
@@ -94,14 +94,14 @@
         <depthImageTopicName>depth/image_raw</depthImageTopicName>
         <depthImageInfoTopicName>depth/camera_info</depthImageInfoTopicName>
         <pointCloudTopicName>depth/points</pointCloudTopicName>
-        <frameName>optical_frame</frameName>
-        <pointCloudCutoff>0.05</pointCloudCutoff>
-        <pointCloudCutoffMax>3.0</pointCloudCutoffMax>
-        <distortionK1>0.00000001</distortionK1>
-        <distortionK2>0.00000001</distortionK2>
-        <distortionK3>0.00000001</distortionK3>
-        <distortionT1>0.00000001</distortionT1>
-        <distortionT2>0.00000001</distortionT2>
+        <frameName>/left_camera_optical_frame</frameName>
+        <pointCloudCutoff>0.105</pointCloudCutoff>
+        <pointCloudCutoffMax>10</pointCloudCutoffMax>
+        <distortionK1>0</distortionK1>
+        <distortionK2>0</distortionK2>
+        <distortionK3>0</distortionK3>
+        <distortionT1>0</distortionT1>
+        <distortionT2>0</distortionT2>
         <CxPrime>0</CxPrime>
         <Cx>0</Cx>
         <Cy>0</Cy>


### PR DESCRIPTION
Updates to the configuration of the simulated depth camera based on information found in [the Intel RealSense D400 Series Datasheet](https://www.intelrealsense.com/wp-content/uploads/2019/10/Intel-RealSense-D400-Series-Datasheet-Oct-2019.pdf). This is mainly updating the range of the depth camera and its horizontal field of view.
