### PR TITLE
Fix velocities being integrated for wheel and visual odometry in Kalman filter

### DIFF
--- a/packages/autonomy/ezrassor_autonomous_control/config/ekf_template.yaml
+++ b/packages/autonomy/ezrassor_autonomous_control/config/ekf_template.yaml
@@ -22,7 +22,7 @@ imu0_remove_gravitational_acceleration: true
 odom0: diff_drive_controller/odom
 odom0_config: [false, false, false,
               false,  false,  false,
-              true, true, false,
+              true, false, false,
               false,  false,  true,
               false,  false,  false]
 odom0_nodelay: false
@@ -33,7 +33,7 @@ odom0_queue_size: 10
 odom1: visual_odom/odom
 odom1_config: [false, false, false,
               false,  false,  false,
-              true, false, false,
+              true, true, false,
               false,  false,  true,
               false,  false,  false]
 odom1_nodelay: false


### PR DESCRIPTION
When I updated the Kalman filter in #318 to also integrate visual odometry's reported linear y velocity, I accidentally changed the value for wheel odometry instead of for visual odometry. This PR fixes that. Testing is the same as for #318.