### PR TITLE
ezrassor_teleop_actions: Bug fix on goal duration, default namespace added for TeleopActionClient

### DIFF
--- a/packages/actions/ezrassor_teleop_actions/scripts/teleop_action_client.py
+++ b/packages/actions/ezrassor_teleop_actions/scripts/teleop_action_client.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python
-
+import os
 import sys
-import rospy
-import actionlib
-
 from ezrassor_teleop_msgs.msg import TeleopAction
 from ezrassor_teleop_msgs.msg import TeleopGoal
+
+if "ROS_NAMESPACE" not in os.environ:
+    """The action server is attached to a particular ezrassor namespace.
+    In order for the client to work, it has to have a default value of being
+    on the ezrassor1 namespace."""
+    os.environ["ROS_NAMESPACE"] = TeleopGoal.DEFAULT_NAMESPACE
+
+# ROS_NAMESPACE must be set before importing rospy
+import rospy
+import actionlib
 
 
 class TeleopActionClient:

--- a/packages/messages/ezrassor_teleop_msgs/action/Teleop.action
+++ b/packages/messages/ezrassor_teleop_msgs/action/Teleop.action
@@ -1,4 +1,5 @@
 # TeleopGoal
+string DEFAULT_NAMESPACE=ezrassor1
 string MOVE_FORWARD_OPERATION=move-forward
 string MOVE_BACKWARD_OPERATION=move-backward
 string ROTATE_LEFT_OPERATION=rotate-left


### PR DESCRIPTION
For the bug that occurred:
---
In the server goal-execution code, I originally had a simple while loop that checked every second to see if the goal state was reached. However, if the user put in a float value like (0.8), the specified duration would not be reached.
- Replaced time.sleep() with rospy.Timer() to execute a callback when the duration has been reached
- The feedback while loop acts independently of this timer

On the default namespace:
---
Working with the TeleopActionClient in the Python interpreter is impossible without first setting the ROS_NAMESPACE env variable since the TeleopActionServer gets spun up per ezrassor. My code change just applies a default value on startup.