### PR TITLE
Add err msg to TeleopActionClient; Support rpy from sim launch

### DIFF
--- a/packages/actions/ezrassor_teleop_actions/source/ezrassor_teleop_actions/teleop_action_client.py
+++ b/packages/actions/ezrassor_teleop_actions/source/ezrassor_teleop_actions/teleop_action_client.py
@@ -1,14 +1,6 @@
-import os
 from ezrassor_teleop_msgs.msg import TeleopAction
 from ezrassor_teleop_msgs.msg import TeleopGoal
 
-if "ROS_NAMESPACE" not in os.environ:
-    """The action server is attached to a particular ezrassor namespace.
-    In order for the client to work, it has to have a default value of being
-    on the ezrassor1 namespace."""
-    os.environ["ROS_NAMESPACE"] = TeleopGoal.DEFAULT_NAMESPACE
-
-# ROS_NAMESPACE must be set before importing rospy
 import rospy
 import actionlib
 
@@ -23,7 +15,15 @@ class TeleopActionClient:
             "teleop_action_server", TeleopAction
         )
 
-        self._client.wait_for_server()
+        connected = self._client.wait_for_server(timeout=rospy.Duration(3))
+        if not connected:
+            rospy.logerr("Unable to connect to Teleop Action Server.")
+            rospy.logerr(
+                "Ensure the action server is running and"
+                + " you have the ROS_NAMESPACE env var set"
+                + " to the namespace of your action server."
+            )
+            return
         rospy.loginfo("Connected to Teleop Action Server.")
 
     def read_instructions(self, instructions_file):

--- a/packages/extras/ezrassor_launcher/launch/configurable_simulation.launch
+++ b/packages/extras/ezrassor_launcher/launch/configurable_simulation.launch
@@ -9,6 +9,9 @@
   <arg name="spawn_x_coords" default="default"/>
   <arg name="spawn_y_coords" default="default"/>
   <arg name="spawn_z_coords" default="default"/>
+  <arg name="spawn_roll" default="default"/>
+  <arg name="spawn_pitch" default="default"/>
+  <arg name="spawn_yaw" default="default"/>
   <arg name="digsite_x_coords" default="default"/>
   <arg name="digsite_y_coords" default="default"/>
   <arg name="world" default="default"/>
@@ -62,6 +65,15 @@
       <arg name="spawn_z_coord"
            value="$(eval str(spawn_z_coords).split()[robot_count - 1])"
            unless="$(eval spawn_z_coords == 'default')"/>
+      <arg name="roll"
+           value="$(eval str(spawn_roll).split()[robot_count - 1])"
+           unless="$(eval spawn_roll == 'default')"/>
+      <arg name="pitch"
+           value="$(eval str(spawn_pitch).split()[robot_count - 1])"
+           unless="$(eval spawn_pitch == 'default')"/>
+      <arg name="yaw"
+           value="$(eval str(spawn_yaw).split()[robot_count - 1])"
+           unless="$(eval spawn_yaw == 'default')"/>
     </include>
 
     <!-- Launch the model controls. -->

--- a/packages/messages/ezrassor_teleop_msgs/action/Teleop.action
+++ b/packages/messages/ezrassor_teleop_msgs/action/Teleop.action
@@ -1,5 +1,4 @@
 # TeleopGoal
-string DEFAULT_NAMESPACE=ezrassor1
 string MOVE_FORWARD_OPERATION=move-forward
 string MOVE_BACKWARD_OPERATION=move-backward
 string ROTATE_LEFT_OPERATION=rotate-left

--- a/packages/simulation/ezrassor_sim_description/launch/model.launch
+++ b/packages/simulation/ezrassor_sim_description/launch/model.launch
@@ -9,7 +9,7 @@
   <arg name="roll" default="0"/>
   <arg name="pitch" default="0"/>
   <arg name="model_id" default="0"/>
-  
+
   <!-- Spawn the robot. -->
   <param name="robot_description"
          command="xacro '$(find ezrassor_sim_description)/urdf/ezrassor.xacro'"/>


### PR DESCRIPTION
The TeleopActionClient will now only work when the ROS_NAMESPACE env var is set. I also added a timeout so that the error message is thrown if no connection is made in the first 3 seconds.

I also added support for roll, pitch, and yaw within configurable_simulation.launch. It uses the same logic as the other robots so you can still define these values for multiple robots at once.